### PR TITLE
Added support for MacVim on OSX and GVim on Linux

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,3 +1,4 @@
 [
-    { "capition": "Open With Vim", "command": "open_with_vim" }
+    { "caption": "Open With Vim", "command": "open_with_vim" },
+	{ "caption": "Open With GVim", "command": "open_with_g_vim"}
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,4 +1,6 @@
 [
-    { "caption": "Open With Vim", "command": "open_with_vim" },
-	{ "caption": "Open With GVim", "command": "open_with_g_vim"}
+    { "caption": "Open With Vim", 
+      "command": "open_with_vim" },
+    { "caption": "Open With Gvim", 
+      "command": "open_with_gvim" }
 ]

--- a/OpenWithVim.py
+++ b/OpenWithVim.py
@@ -1,19 +1,40 @@
 import sublime
 import sublime_plugin
 import subprocess
+import platform
 
 class OpenWithVimCommand(sublime_plugin.WindowCommand):
-    def run(self):
-        terminal = "gnome-terminal"
-        option = "--command"
-        vim = "/usr/bin/vim"
-        path = None
-
+    def get_path(self):
         if self.window.active_view():
-            path = "\"" + self.window.active_view().file_name() + "\""
+            return self.window.active_view().file_name()
         else:
             sublime.error_message(__name__ + ": No file to open.")
-            return
+            return None
 
-        args = [terminal, option, vim + " " + path]
+    def run(self):
+        path = self.get_path()
+        if path is not None:
+            self.open_vim(path)
+
+    def open_vim(self, path):
+        local_os = platform.system()
+        if local_os == 'Linux':
+            terminal = "gnome-terminal"
+            option = "--command"
+            vim = "/usr/bin/vim"
+            args = [terminal, option, vim + ' "' + path + '"']
+        else:
+            sublime.error_message("Sorry, I don't know how to open terminal vim on this platform: %s. Try open_with_gvim" % local_os)
+            return
         subprocess.Popen(args)
+
+
+class OpenWithGvimCommand(OpenWithVimCommand):
+    def open_vim(self, path):
+        local_os = platform.system()
+        if local_os == 'Darwin':
+            args = ["mvim", path]
+        else:
+            args = ["gvim", path]
+        subprocess.Popen(args)
+

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Installation
 ------------
 
     $ cd ~/.config/sublime-text-2/Packages/
-    $ git clone https://github.com/itiut/sublime-text-2-open-with-vim OpenWithVim
+    $ git clone https://github.com/rdeits/sublime-text-2-open-with-vim OpenWithVim
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ Usage
 
 add the following to `User/Default (Linux).sublime-keymap`:
 
-    { "keys": ["ctrl+shift+alt+i"], "command": "open_with_vim" }
-	{ "keys": ["ctrl+alt+e"], "command": "open_with_gvim"},
+    { "keys": ["ctrl+shift+alt+i"], "command": "open_with_vim" },
+	{ "keys": ["ctrl+alt+e"], "command": "open_with_gvim"}
 
 AND/OR add the following to `User/Default (OSX).sublime-keymap`:
-	{ "keys": ["super+ctrl+e"], "command": "open_with_gvim" },
+
+	{ "keys": ["super+ctrl+e"], "command": "open_with_gvim" }
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Sublime Text 2 Open With Vim
 ============================
-Open current file with vim on terminal.
-This script works only for Linux.
+Open the current file in Vim. This works in terminal and GVim on Linux
+and MacVim on OSX.
 
 Installation
 ------------
@@ -16,3 +16,8 @@ Usage
 add the following to `User/Default (Linux).sublime-keymap`:
 
     { "keys": ["ctrl+shift+alt+i"], "command": "open_with_vim" }
+	{ "keys": ["ctrl+alt+e"], "command": "open_with_gvim"},
+
+AND/OR add the following to `User/Default (OSX).sublime-keymap`:
+	{ "keys": ["super+ctrl+e"], "command": "open_with_gvim" },
+


### PR DESCRIPTION
There's now a second command, open_with_gvim, which pulls up GVim on Linux and MacVim on OSX. I haven't added terminal support for OSX, but that could be done as well. 
