### PR TITLE
pass a current line number to vim

### DIFF
--- a/OpenWithVim.py
+++ b/OpenWithVim.py
@@ -3,6 +3,11 @@ import sublime_plugin
 import subprocess
 
 class OpenWithVimCommand(sublime_plugin.WindowCommand):
+    def current_line(self, view):
+        row, col = view.rowcol(view.sel()[0].begin())
+        row += 1
+        return row
+
     def run(self):
         terminal = "gnome-terminal"
         option = "--command"
@@ -15,5 +20,7 @@ class OpenWithVimCommand(sublime_plugin.WindowCommand):
             sublime.error_message(__name__ + ": No file to open.")
             return
 
-        args = [terminal, option, vim + " " + path]
-        subprocess.Popen(args)
+        line_num = self.current_line(self.window.active_view())
+
+        command = [terminal, option, vim + ' +' + str(line_num) + ' ' + path]
+        subprocess.Popen(command)


### PR DESCRIPTION
When vim was opened, the cursor position of SublimeText was passed. 

translate by http://www.excite.co.jp/world/english/
(vimを開いたときにSublimeTextのカーソル位置を渡すようにした)
